### PR TITLE
Default GCP service account key for registry storage

### DIFF
--- a/domain.tf
+++ b/domain.tf
@@ -33,13 +33,13 @@ resource "tls_cert_request" "req" {
   dns_names       = ["*.${local.base_domain}"]
 
   subject {
-    common_name     = "*.${local.base_domain}"
-    organization    = "Astronomer"
+    common_name  = "*.${local.base_domain}"
+    organization = "Astronomer"
   }
 }
 
 resource "acme_certificate" "lets_encrypt" {
-  account_key_pem = acme_registration.user_registration.account_key_pem
+  account_key_pem         = acme_registration.user_registration.account_key_pem
   certificate_request_pem = tls_cert_request.req.cert_request_pem
 
   dns_challenge {

--- a/firewalls.tf
+++ b/firewalls.tf
@@ -10,7 +10,7 @@ resource "google_compute_firewall" "bastion_iap_ingress" {
     ports    = ["22"]
   }
 
-  source_ranges = var.iap_cidr_ranges
+  source_ranges           = var.iap_cidr_ranges
   target_service_accounts = [google_service_account.bastion.email]
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -28,3 +28,9 @@ resource "google_project_iam_audit_config" "iap" {
   service = "iap.googleapis.com"
 }
 
+data "google_compute_default_service_account" "default" {}
+
+resource "google_service_account_key" "default_key" {
+  service_account_id = "${data.google_compute_default_service_account.default.name}"
+  public_key_type    = "TYPE_X509_PEM_FILE"
+}

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -13,7 +13,7 @@ resource "google_container_node_pool" "node_pool_mt" {
 
   lifecycle {
     # ignore_changes =["node_config[0].labels", "node_config[0].taint"]
-    ignore_changes =["node_config"]
+    ignore_changes = ["node_config"]
   }
 
   location = var.region

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,3 +42,7 @@ output "container_registry_bucket_name" {
   description = "Cloud Storage Bucket Name to be used for Container Registry"
 }
 
+output "gcp_default_service_account_key" {
+  value = "${base64decode(google_service_account_key.default_key.private_key)}"
+  sensitive = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,7 @@ output "tls_key" {
 }
 
 output "tls_cert" {
-  value     = <<EOF
+  value = <<EOF
 ${acme_certificate.lets_encrypt.certificate_pem}
 ${acme_certificate.lets_encrypt.issuer_pem}
 EOF


### PR DESCRIPTION
* Part 1/3(?)
* Adds data source for default gcp service account
* Adds service account key resource for default gcp service account
* Some files changed after `terraform fmt`
* Related to astronomer/biz-cloud#72
