### PR TITLE
add back in service account key for bucket that I accidentally deleted

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,6 @@
+data "google_compute_default_service_account" "default" {}
+
+resource "google_service_account_key" "default_key" {
+  service_account_id = "${data.google_compute_default_service_account.default.name}"
+  public_key_type    = "TYPE_X509_PEM_FILE"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,3 +47,8 @@ resource "null_resource" "dependency_setter" {}
 output "depended_on" {
   value = "${null_resource.dependency_setter.id}-${timestamp()}"
 }
+
+output "gcp_default_service_account_key" {
+  value = "${base64decode(google_service_account_key.default_key.private_key)}"
+  sensitive = true
+}


### PR DESCRIPTION
I was attempting to clean up the IAM user stuff. ended up deleting the whole iam.tf file, oops