### PR TITLE
Add firewall rule for knative webhook

### DIFF
--- a/firewalls.tf
+++ b/firewalls.tf
@@ -34,7 +34,7 @@ resource "google_compute_firewall" "gke_knative_serving_webhook_allow" {
   count       = var.enable_knative ? 1 : 0
   name        = "${var.deployment_id}-knative-webhook-allow-ingress"
   network     = google_compute_network.core.self_link
-  description = "Allow GKE master to communicate ti knative webhook"
+  description = "Allow GKE master to communicate with node pools on 8443 for the knative webhook"
   priority    = 1000
   direction   = "INGRESS"
 

--- a/firewalls.tf
+++ b/firewalls.tf
@@ -29,3 +29,20 @@ resource "google_compute_firewall" "bastion_deny_all_ingress" {
 
   target_service_accounts = [google_service_account.bastion[0].email]
 }
+
+resource "google_compute_firewall" "gke_knative_serving_webhook_allow" {
+  count       = var.enable_knative ? 1 : 0
+  name        = "${var.deployment_id}-knative-webhook-allow-ingress"
+  network     = google_compute_network.core.self_link
+  description = "Allow GKE master to communicate ti knative webhook"
+  priority    = 1000
+  direction   = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8443"]
+  }
+
+  source_ranges = [google_container_cluster.primary.private_cluster_config.0.master_ipv4_cidr_block]
+  target_tags   = local.network_tags
+}

--- a/firewalls.tf
+++ b/firewalls.tf
@@ -44,5 +44,5 @@ resource "google_compute_firewall" "gke_knative_serving_webhook_allow" {
   }
 
   source_ranges = [google_container_cluster.primary.private_cluster_config.0.master_ipv4_cidr_block]
-  target_tags   = local.network_tags
+  target_tags   = local.gke_nodepool_network_tags
 }

--- a/locals.tf
+++ b/locals.tf
@@ -54,4 +54,6 @@ users:
   )
   # min_master_version = var.min_master_version == "" ? data.google_container_engine_versions.gke.latest_master_version : var.min_master_version
   # node_version = var.node_version == "" ? data.google_container_engine_versions.gke.latest_node_version : var.node_version
+
+  network_tags = compact([var.enable_knative ? "knative-webook" : ""])
 }

--- a/locals.tf
+++ b/locals.tf
@@ -4,6 +4,14 @@ data "google_container_engine_versions" "gke" {
   location = local.region
 }
 
+data "google_compute_instance_group" "sample_instance_group" {
+  self_link = replace(google_container_node_pool.node_pool_platform.instance_group_urls[0], "instanceGroupManagers", "instanceGroups")
+}
+
+data "google_compute_instance" "sample_instance" {
+  self_link = tolist(data.google_compute_instance_group.sample_instance_group.instances)[0]
+}
+
 locals {
   project                   = data.google_compute_zones.available.project
   region                    = data.google_compute_zones.available.region
@@ -55,5 +63,5 @@ users:
   # min_master_version = var.min_master_version == "" ? data.google_container_engine_versions.gke.latest_master_version : var.min_master_version
   # node_version = var.node_version == "" ? data.google_container_engine_versions.gke.latest_node_version : var.node_version
 
-  network_tags = compact([var.enable_knative ? "knative-webook" : ""])
+  gke_nodepool_network_tags = data.google_compute_instance.sample_instance.tags
 }

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -64,8 +64,6 @@ resource "google_container_node_pool" "node_pool_mt" {
       "astronomer.io/multi-tenant" = "true"
     }
 
-    tags = local.network_tags
-
     machine_type = var.machine_type
 
     oauth_scopes = [
@@ -158,8 +156,6 @@ resource "google_container_node_pool" "node_pool_platform" {
     labels = {
       "astronomer.io/multi-tenant" = "false"
     }
-
-    tags = local.network_tags
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -64,6 +64,8 @@ resource "google_container_node_pool" "node_pool_mt" {
       "astronomer.io/multi-tenant" = "true"
     }
 
+    tags = local.network_tags
+
     machine_type = var.machine_type
 
     oauth_scopes = [
@@ -156,6 +158,8 @@ resource "google_container_node_pool" "node_pool_platform" {
     labels = {
       "astronomer.io/multi-tenant" = "false"
     }
+
+    tags = local.network_tags
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "bastion_proxy_command" {
-  value = "gcloud beta compute ssh --zone ${google_compute_instance.bastion[0].zone} ${google_compute_instance.bastion[0].name} --tunnel-through-iap --ssh-flag='-L 1234:127.0.0.1:8888 -C -N'"
+  value = length(google_compute_instance.bastion) > 0 ? "gcloud beta compute ssh --zone ${google_compute_instance.bastion[0].zone} ${google_compute_instance.bastion[0].name} --tunnel-through-iap --ssh-flag='-L 1234:127.0.0.1:8888 -C -N'" : "Not applicable - no bastion"
 }
 
 output "db_connection_string" {

--- a/variables.tf
+++ b/variables.tf
@@ -137,3 +137,8 @@ variable "platform_node_pool_taints" {
   type        = "list"
   default     = []
 }
+
+variable "enable_knative" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
This is based on a solution mentioned here: https://github.com/knative/serving/issues/4868#issuecomment-523593501


Solution mentioned at  
https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules says that we should get the tag from the [existing firewall rule ](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#view_firewall_rules). And then add a firewall rule to that tag. However, unfortunately, there is no way in terraform to get that tag from existing firewall rule as there is no **_data_** source. Hence the solution in the PR adds a new tag to the nodes but this causes the node pools to be re-created (the first new one is created and then the existing one is deleted).