### PR TITLE
Allow Google IAP to access SSH on nodes

### DIFF
--- a/firewalls.tf
+++ b/firewalls.tf
@@ -45,3 +45,19 @@ resource "google_compute_firewall" "gke_webhook_allow" {
   source_ranges = [google_container_cluster.primary.private_cluster_config.0.master_ipv4_cidr_block]
   target_tags   = local.gke_nodepool_network_tags
 }
+
+resource "google_compute_firewall" "gke_iap_ssh_to_nodes" {
+  name        = "${var.deployment_id}-allow-ingress-from-google-iap-to-nodes"
+  network     = google_compute_network.core.self_link
+  description = "Allow GCP IAP to use SSH to connect to GKE nodes"
+  priority    = 2000
+  direction   = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = var.iap_cidr_ranges
+  target_tags   = local.gke_nodepool_network_tags
+}


### PR DESCRIPTION
The justification is in this comment and the following two comments https://github.com/astronomer/issues/issues/868#issuecomment-592538132

In summary, to access a node in GKE using google IAP, we need to provide IAP access to the nodes because we are not using the default network that includes allow-default-ssh rule.

Example command to connect:
```
gcloud beta compute ssh --zone us-east4-c gke-staging-cluster-staging-mt-01-08--73603e9e-1gs6 --tunnel-through-iap --project astronomer-cloud-staging
```

IP range documentation: https://cloud.google.com/iap/docs/using-tcp-forwarding

I applied this policy manually via the UI, and the above command started working (stage cloud)