### PR TITLE
Add green platform node pool

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -149,17 +149,17 @@ steps:
     repo:
       - astronomer/terraform-google-astronomer-gcp
 
-- name: update_cloud_module
-  image: docker:git
-  environment:
-    DEPLOY_KEY:
-      from_secret: DEPLOY_KEY_CLOUD_MODULE
-  commands:
-    - pipeline/update_cloud_module.sh
-  when:
-    event:
-      - tag
-    status:
-      - success
-    repo:
-      - astronomer/terraform-google-astronomer-gcp
+# - name: update_cloud_module
+#   image: docker:git
+#   environment:
+#     DEPLOY_KEY:
+#       from_secret: DEPLOY_KEY_CLOUD_MODULE
+#   commands:
+#     - pipeline/update_cloud_module.sh
+#   when:
+#     event:
+#       - tag
+#     status:
+#       - success
+#     repo:
+#       - astronomer/terraform-google-astronomer-gcp

--- a/examples/from_scratch/main.tf
+++ b/examples/from_scratch/main.tf
@@ -1,7 +1,7 @@
 variable "deployment_id" {}
 
 variable "zonal" {
-  default = true
+  default = false
 }
 
 module "astronomer_gcp" {

--- a/locals.tf
+++ b/locals.tf
@@ -5,7 +5,7 @@ data "google_container_engine_versions" "gke" {
 }
 
 data "google_compute_instance_group" "sample_instance_group" {
-  self_link = replace(google_container_node_pool.node_pool_platform.instance_group_urls[0], "instanceGroupManagers", "instanceGroups")
+  self_link = var.enable_blue_platform_node_pool ? replace(google_container_node_pool.node_pool_platform[1].instance_group_urls[0], "instanceGroupManagers", "instanceGroups") : replace(google_container_node_pool.node_pool_platform_green[1].instance_group_urls[0], "instanceGroupManagers", "instanceGroups")
 }
 
 data "google_compute_instance" "sample_instance" {

--- a/locals.tf
+++ b/locals.tf
@@ -5,7 +5,7 @@ data "google_container_engine_versions" "gke" {
 }
 
 data "google_compute_instance_group" "sample_instance_group" {
-  self_link = var.enable_blue_platform_node_pool ? replace(google_container_node_pool.node_pool_platform[1].instance_group_urls[0], "instanceGroupManagers", "instanceGroups") : replace(google_container_node_pool.node_pool_platform_green[1].instance_group_urls[0], "instanceGroupManagers", "instanceGroups")
+  self_link = var.enable_blue_platform_node_pool ? replace(google_container_node_pool.node_pool_platform[0].instance_group_urls[0], "instanceGroupManagers", "instanceGroups") : replace(google_container_node_pool.node_pool_platform_green[0].instance_group_urls[0], "instanceGroupManagers", "instanceGroups")
 }
 
 data "google_compute_instance" "sample_instance" {

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -211,7 +211,7 @@ resource "google_container_node_pool" "node_pool_dynamic_pods" {
 
   autoscaling {
     min_node_count = "0"
-    max_node_count = var.zonal_cluster ? var.max_node_count : ceil(var.max_node_count / 3)
+    max_node_count = var.zonal_cluster ? var.max_node_count_dynamic : ceil(var.max_node_count_dynamic / 3)
   }
 
   management {
@@ -228,7 +228,7 @@ resource "google_container_node_pool" "node_pool_dynamic_pods" {
       "astronomer.io/dynamic-pods" = "true"
     }
 
-    machine_type = var.machine_type
+    machine_type = var.machine_type_dynamic
     disk_size_gb = var.disk_size_dynamic
 
     oauth_scopes = [
@@ -242,7 +242,7 @@ resource "google_container_node_pool" "node_pool_dynamic_pods" {
     ]
 
     dynamic "taint" {
-      for_each = var.dp_node_pool_taints
+      for_each = var.dynamic_node_pool_taints
       content {
         effect = taint.value.effect
         key    = taint.value.key

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,7 +59,9 @@ output "container_registry_bucket_name" {
 resource "null_resource" "dependency_setter" {
   depends_on = [google_container_cluster.primary,
     google_container_node_pool.node_pool_mt,
+    google_container_node_pool.node_pool_mt_green,
     google_container_node_pool.node_pool_platform,
+    google_container_node_pool.node_pool_platform_green,
     google_sql_database_instance.instance,
   acme_certificate.lets_encrypt]
 

--- a/variables.tf
+++ b/variables.tf
@@ -290,3 +290,8 @@ variable "enable_gvisor_dynamic" {
   default     = false
   description = "Should this module configure the dynamic node pool for the gvisor runtime?"
 }
+
+variable "machine_type_dynamic" {
+  default     = "n1-standard-4"
+  description = "The GCP machine type for the bastion"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "machine_type_platform" {
   description = "The GCP machine type for GKE worker nodes running platform components"
 }
 
+variable "green_machine_type_platform" {
+  default     = "n1-standard-4"
+  description = "The GCP machine type for GKE worker nodes running platform components"
+}
+
 variable "machine_type_bastion" {
   default     = "g1-small"
   description = "The GCP machine type for the bastion"
@@ -190,4 +195,10 @@ variable "db_max_connections" {
   type        = number
   default     = 0
   description = "Configure the max connections to the database. If omitted, it will not be configured (default of zero indicates do not specify)."
+}
+
+variable "enable_green_platform_node_pool" {
+  type        = bool
+  default     = false
+  description = "Turn on the green platform node pool"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,65 +8,15 @@ variable "dns_managed_zone" {
   description = "The name of the google dns managed zone we should use"
 }
 
-variable "disk_size_multi_tenant" {
-  default     = 100
-  type        = number
-  description = "Number of GB available on Nodes' local disks for the multi-tenant node pool, which runs Airflow deployments"
-}
-
-variable "disk_size_platform" {
-  default     = 100
-  type        = number
-  description = "Number of GB available on Nodes' local disks for the platform node pool, which runs Astronomer components"
-}
-
-variable "disk_size_dynamic" {
-  default     = 100
-  type        = number
-  description = "Number of GB available on Nodes' local disks for the dynamic, multi-tenant node pool, which runs Airflow deployments' ephemeral pods such as KubeExecutor pods and Kubernetes Pod Operator pods"
-}
-
 variable "kube_version_gke" {
   default     = "1.14"
   description = "The kubernetes version to use in GKE"
-}
-
-variable "machine_type" {
-  default     = "n1-standard-4"
-  description = "The GCP machine type for GKE worker nodes running multi-tenant workloads"
-}
-
-variable "machine_type_platform" {
-  default     = "n1-standard-4"
-  description = "The GCP machine type for GKE worker nodes running platform components"
-}
-
-variable "green_machine_type_platform" {
-  default     = "n1-standard-4"
-  description = "The GCP machine type for GKE worker nodes running platform components"
 }
 
 variable "machine_type_bastion" {
   default     = "g1-small"
   description = "The GCP machine type for the bastion"
 }
-
-variable "max_node_count" {
-  default     = 10
-  description = "The approximate maximum number of nodes in the GKE worker node pool. The exact max will be 3 * ceil(your_value / 3.0) ."
-}
-
-/*
-variable "min_master_version" {
-  default     = ""
-  description = "The minimum version of the master. Default is the latest available from the API."
-}
-
-variable "node_version" {
-  default     = ""
-  description = "The version of Kubernetes in GKE cluster. Default is the latest available from the API."
-}
-*/
 
 variable "gke_secondary_ip_ranges_pods" {
   default     = "10.32.0.0/14"
@@ -133,12 +83,6 @@ variable "wait_for" {
   description = "How long to wait after GKE cluster is up in order for the cluster to stabilize"
 }
 
-variable "enable_gvisor" {
-  type        = bool
-  default     = false
-  description = "Should this module configure the multi-tenant node pool for the gvisor runtime?"
-}
-
 variable "do_not_create_a_record" {
   type    = bool
   default = false
@@ -149,34 +93,10 @@ variable "lets_encrypt" {
   default = true
 }
 
-variable "mt_node_pool_taints" {
-  description = "Taints to apply to the Multi-Tenant Node Pool "
-  type        = "list"
-  default     = []
-}
-
-variable "platform_node_pool_taints" {
-  description = "Taints to apply to the Platform Node Pool "
-  type        = "list"
-  default     = []
-}
-
-variable "dp_node_pool_taints" {
-  description = "Taints to apply to the Dynamic-Pods Node Pool "
-  type        = "list"
-  default     = []
-}
-
 variable "webhook_ports" {
   type        = list(string)
   default     = []
   description = "When custom API services are added to the cluster, the corresponding ports must be opened on the network's firewall, allowing GKE's control plane to access the api service backend running in the node pool. The ports should be provided as a list of strings."
-}
-
-variable "create_dynamic_pods_nodepool" {
-  type        = bool
-  default     = false
-  description = "If true, creates a NodePool for the pods spun up using KubernetesPodsOperator or KubernetesExecutor"
 }
 
 variable "enable_gke_metered_billing" {
@@ -197,8 +117,176 @@ variable "db_max_connections" {
   description = "Configure the max connections to the database. If omitted, it will not be configured (default of zero indicates do not specify)."
 }
 
+
+### Node Pool settings
+# Blue / Green node pools feature is to allow Terraform users
+# careful control of node pool changes
+
+
+## Platform node pool: Blue
+
+variable "enable_blue_platform_node_pool" {
+  type        = bool
+  default     = true
+  description = "Turn on the blue platform node pool"
+}
+
+variable "machine_type_platform_blue" {
+  default     = "n1-standard-4"
+  type        = string
+  description = "The GCP machine type for GKE worker nodes running platform components"
+}
+
+variable "disk_size_platform_blue" {
+  default     = 100
+  type        = number
+  description = "Number of GB available on Nodes' local disks for the platform node pool, which runs Astronomer components"
+}
+
+variable "max_node_count_platform_blue" {
+  default     = 10
+  type        = number
+  description = "The approximate maximum number of nodes in the platform node pool. The exact max will be 3 * ceil(your_value / 3.0) in the case of regional cluster, and exactly as configured in the case of zonal cluster."
+}
+
+variable "platform_node_pool_taints_blue" {
+  description = "Taints to apply to the platform node pool "
+  type        = list
+  default     = []
+}
+
+## Platform node pool: Green
+
 variable "enable_green_platform_node_pool" {
   type        = bool
   default     = false
   description = "Turn on the green platform node pool"
+}
+
+variable "machine_type_platform_green" {
+  default     = "n1-standard-4"
+  type        = string
+  description = "The GCP machine type for GKE worker nodes running platform components"
+}
+
+variable "disk_size_platform_green" {
+  default     = 100
+  type        = number
+  description = "Number of GB available on Nodes' local disks for the platform node pool, which runs Astronomer components"
+}
+
+variable "max_node_count_platform_green" {
+  default     = 10
+  type        = number
+  description = "The approximate maximum number of nodes in the platfor node pool. The exact max will be 3 * ceil(your_value / 3.0) in the case of regional cluster, and exactly as configured in the case of zonal cluster."
+}
+
+variable "platform_node_pool_taints_green" {
+  description = "Taints to apply to the Platform Node Pool "
+  type        = list
+  default     = []
+}
+
+
+## Multi-tenant node pool: Blue
+
+variable "enable_blue_mt_node_pool" {
+  type        = bool
+  default     = true
+  description = "Turn on the blue multi-tenant node pool"
+}
+
+variable "machine_type_multi_tenant_blue" {
+  default     = "n1-standard-4"
+  description = "The GCP machine type for GKE worker nodes running multi-tenant workloads"
+}
+
+variable "disk_size_multi_tenant_blue" {
+  default     = 100
+  type        = number
+  description = "Number of GB available on Nodes' local disks for the multi-tenant node pool, which runs Airflow deployments"
+}
+
+variable "max_node_count_multi_tenant_blue" {
+  default     = 10
+  description = "The approximate maximum number of nodes in the GKE multi-tenant node pool. The exact max will be 3 * ceil(your_value / 3.0) in the case of regional cluster, and exactly as configured in the case of zonal cluster."
+}
+
+variable "mt_node_pool_taints_blue" {
+  description = "Taints to apply to the Multi-Tenant Node Pool "
+  type        = "list"
+  default     = []
+}
+
+variable "enable_gvisor_blue" {
+  type        = bool
+  default     = false
+  description = "Should this module configure the multi-tenant node pool for the gvisor runtime?"
+}
+
+## Multi-tenant node pool: Green
+
+variable "enable_green_mt_node_pool" {
+  type        = bool
+  default     = false
+  description = "Turn on the green multi-tenant node pool"
+}
+
+variable "machine_type_multi_tenant_green" {
+  default     = "n1-standard-4"
+  description = "The GCP machine type for GKE worker nodes running multi-tenant workloads"
+}
+
+variable "disk_size_multi_tenant_green" {
+  default     = 100
+  type        = number
+  description = "Number of GB available on Nodes' local disks for the multi-tenant node pool, which runs Airflow components"
+}
+
+variable "max_node_count_multi_tenant_green" {
+  default     = 10
+  description = "The approximate maximum number of nodes in the GKE multi-tenant node pool. The exact max will be 3 * ceil(your_value / 3.0) in the case of regional cluster, and exactly as configured in the case of zonal cluster."
+}
+
+variable "mt_node_pool_taints_green" {
+  description = "Taints to apply to the Multi-Tenant Node Pool"
+  type        = "list"
+  default     = []
+}
+
+variable "enable_gvisor_green" {
+  type        = bool
+  default     = false
+  description = "Should this module configure the multi-tenant node pool for the gvisor runtime?"
+}
+
+## Dynamic node pool: we do not have Blue / Green for this one, just a single node pool
+
+variable "create_dynamic_pods_nodepool" {
+  type        = bool
+  default     = false
+  description = "If true, creates a NodePool for the pods spun up using KubernetesPodsOperator or KubernetesExecutor"
+}
+
+variable "disk_size_dynamic" {
+  default     = 100
+  type        = number
+  description = "Number of GB available on Nodes' local disks for the dynamic node pool, which runs Airflow deployments' ephemeral pods such as KubeExecutor pods and Kubernetes Pod Operator pods"
+}
+
+variable "dynamic_node_pool_taints" {
+  description = "Taints to apply to the dynamic node pool "
+  type        = "list"
+  default     = []
+}
+
+variable "max_node_count_dynamic" {
+  default     = 10
+  description = "The approximate maximum number of nodes in the GKE dynamic node pool. The exact max will be 3 * ceil(your_value / 3.0) for a regional cluster, or exactly as configured for zonal cluster."
+}
+
+variable "enable_gvisor_dynamic" {
+  type        = bool
+  default     = false
+  description = "Should this module configure the dynamic node pool for the gvisor runtime?"
 }


### PR DESCRIPTION
I removed the "depends_on" node pool stuff also and it seems like it works now, I expect TF provider got an update. however, it still takes the same amount of time. I think TF handles the collision, but there is still a sequential requirement for adding or removing node pools in GKE.

the point of this change is to enable cloud operations to do blue green node pool swapping. we will do only for the platform node pool at this point.

@jpweber we discussed this as a work around for the prom issue (WAL too big so OOM with entire node's memory and crashloop). I expect we will still do this before next week, but the short term plan is delete WAL, wait two hours, delete the other WAL. perhaps some solution like we init container delete the WAL and PDB or something to keep both running for 2 hours before doing the next? but that would be a pain to wait for in helm unless there is a way to configure helm to not wait on those resources. idk