### PR TITLE
bug fix for destory issue

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -40,8 +40,13 @@ users:
 
   EOF
   bastion_name              = "${var.deployment_id}-bastion"
-  # fix bug during destory that leaves the random_string.postgres_airflow_password empty and errors out
-  postgres_airflow_password = var.postgres_airflow_password == "" ? random_string.postgres_airflow_password != [] ? random_string.postgres_airflow_password[0].result : "" : var.postgres_airflow_password
+  # the second ternary is due to a bug during terraform destroy that the random_string.postgres_airflow_password
+  # is an empty array and causes an error.  this just checks and lets it keep going through destroy successfully.
+  postgres_airflow_password = (
+    var.postgres_airflow_password == "" 
+      ? random_string.postgres_airflow_password != [] ? random_string.postgres_airflow_password[0].result : "" 
+      : var.postgres_airflow_password
+  )
   core_network_id = format(
     "projects/%s/global/networks/%s",
     google_compute_network.core.project,

--- a/locals.tf
+++ b/locals.tf
@@ -40,7 +40,8 @@ users:
 
   EOF
   bastion_name              = "${var.deployment_id}-bastion"
-  postgres_airflow_password = var.postgres_airflow_password == "" ? random_string.postgres_airflow_password[0].result : var.postgres_airflow_password
+  # fix bug during destory that leaves the random_string.postgres_airflow_password empty and errors out
+  postgres_airflow_password = var.postgres_airflow_password == "" ? random_string.postgres_airflow_password != [] ? random_string.postgres_airflow_password[0].result : "" : var.postgres_airflow_password
   core_network_id = format(
     "projects/%s/global/networks/%s",
     google_compute_network.core.project,


### PR DESCRIPTION
during a `terraform destroy ...` command, the following would throw an error as the value wasn't present because it had been destroyed (i think).

this just checks for the existence of that value to stop error and allow clean terraform destroy.

# IMPORTANT
i chose to push this into the `gke-channels` branch instead of master, as this is a child of that channel, and qa cluster was created with the `gke-channels` branch.  

we may want to think about how/where/when this gets merged, so i just wanted to bring that up...


thoughts?