### PR TITLE
Use ipify vs icanhazip

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "random_string" "password" {
 }
 
 data "http" "local_ip" {
-  url = "http://icanhazip.com/"
+  url = "https://api.ipify.org/"
 }
 
 # data "google_container_engine_versions" "versions" {


### PR DESCRIPTION
icanhazip.com has caused some issues in the past due to being unavailable. This change swiches to ipify.org

Example failure: <https://app.circleci.com/pipelines/github/astronomer/google-environments/8177/workflows/acd7356d-f3a3-4cdb-9628-a26eebe53192/jobs/11737>

Related to astronomer/issues#2290