### PR TITLE
adding disk types

### DIFF
--- a/node_pools.tf
+++ b/node_pools.tf
@@ -308,6 +308,7 @@ resource "google_container_node_pool" "dynamic_blue_node_pool" {
 
     machine_type = var.machine_type_dynamic_blue
     disk_size_gb = var.disk_size_dynamic_blue
+    disk_type    = var.disk_type_dynamic_blue
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
@@ -391,6 +392,7 @@ resource "google_container_node_pool" "dynamic_green_node_pool" {
 
     machine_type = var.machine_type_dynamic_green
     disk_size_gb = var.disk_size_dynamic_green
+    disk_type    = var.disk_type_dynamic_green
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",

--- a/variables.tf
+++ b/variables.tf
@@ -357,6 +357,12 @@ variable "disk_size_dynamic_blue" {
   description = "Number of GB available on Nodes' local disks for the blue dynamic node pool"
 }
 
+variable "disk_type_dynamic_blue" {
+  default     = "pd-standard"
+  type        = string
+  description = "Type of the disk attached to each node (e.g. 'pd-standard', 'pd-balanced' or 'pd-ssd'). If unspecified, the default disk type is 'pd-standard'"
+}
+
 variable "max_node_count_dynamic_blue" {
   default     = 10
   description = "The approximate maximum number of nodes in the blue dynamic node pool. The exact max will be 3 * ceil(your_value / 3.0) in the case of regional cluster, and exactly as configured in the case of zonal cluster."
@@ -397,6 +403,12 @@ variable "disk_size_dynamic_green" {
   default     = 100
   type        = number
   description = "Number of GB available on Nodes' local disks for the green dynamic node pool"
+}
+
+variable "disk_type_dynamic_green" {
+  default     = "pd-standard"
+  type        = string
+  description = "Type of the disk attached to each node (e.g. 'pd-standard', 'pd-balanced' or 'pd-ssd'). If unspecified, the default disk type is 'pd-standard'"
 }
 
 variable "max_node_count_dynamic_green" {


### PR DESCRIPTION
# overview

in `astonomer_cloud` we are pointing to a `1.1.0` tag, as master has more on it then the tag which added to more and more changes in the plan file....

i would like to tag off this branch to avoid that as we move it forward, and come back w/ the changes to master that daniel had made (its labels and what not)

here is a `google-environments` plan that shows this doesn't change anything extra (i have not used the flags yet, gotta start somewhere with this...)

https://app.circleci.com/pipelines/github/astronomer/google-environments/8399/workflows/58a80de3-724d-4ac8-9654-d8414d469205/jobs/13006/parallel-runs/0/steps/0-102