### PR TITLE
Egress ip test

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -54,7 +54,7 @@ resource "google_compute_router_nat" "nat" {
   min_ports_per_vm                   = 128
   router                             = google_compute_router.router.name
   nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = var.natgateway_external_ip_list == [] ? google_compute_address.address.*.self_link : var.natgateway_external_ip_list
+  nat_ips                            = length(var.natgateway_external_ip_list) == 0 ? google_compute_address.address.*.self_link : var.natgateway_external_ip_list
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   tcp_established_idle_timeout_sec   = 7200
 

--- a/network.tf
+++ b/network.tf
@@ -54,7 +54,7 @@ resource "google_compute_router_nat" "nat" {
   min_ports_per_vm                   = 128
   router                             = google_compute_router.router.name
   nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = google_compute_address.address.*.self_link
+  nat_ips                            = var.natgateway_external_ip_list == [] ? google_compute_address.address.*.self_link : var.natgateway_external_ip_list
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   tcp_established_idle_timeout_sec   = 7200
 

--- a/variables.tf
+++ b/variables.tf
@@ -449,6 +449,7 @@ variable "enable_spotinist" {
 }
 
 variable "natgateway_external_ip_list" {
+  default     = []
   type        = list
   description = "list of ips for the egress nat gateway to use (use if you have manually created these outside terraform)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -451,5 +451,5 @@ variable "enable_spotinist" {
 variable "natgateway_external_ip_list" {
   default     = []
   type        = list
-  description = "list of ips for the egress nat gateway to use (use if you have manually created these outside terraform)"
+  description = "this list is not actually of IPs, but of google URIs for the IP resource. example: https://www.googleapis.com/compute/v1/projects/astronomer-cloud-dev-236021/regions/us-east4/addresses/dev-nat-external-address-0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -447,3 +447,8 @@ variable "enable_spotinist" {
   type        = bool
   description = "Run the nodes using Spotinist"
 }
+
+variable "natgateway_external_ip_list" {
+  type        = list
+  description = "list of ips for the egress nat gateway to use (use if you have manually created these outside terraform)"
+}


### PR DESCRIPTION
added ability to supply a list of ip address to terraform nat gateway, as in production we created them outside of terraform and we need to be able to incorporate them into terraform so terraform will not try and delete them / un-attach them.

this was tested all the way up to the `google-environments` project with having that value set and without having it set for backwards compatibility testing.  seems to work just fine....