### PR TITLE
Allow specifying the image_type in each node_pool.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+  - repo: local
+    hooks:
+      - id: kube_version_gke
+        name: Ensure no prefixed v on kubernetes version
+        entry: '"v[0-9]+\.[0-9]+\.[0-9]+-gke'
+        language: pygrep
+        types: [terraform]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.74.1
     hooks:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @astronomer/platform-infra

--- a/terraform/node_pools.tf
+++ b/terraform/node_pools.tf
@@ -84,8 +84,8 @@ resource "google_container_node_pool" "node_pool_mt_green" {
       }
     }
 
-    # COS_CONTAINERD is required for sandbox_config to work
-    image_type = var.enable_gvisor_green ? "COS_CONTAINERD" : "COS"
+    # COS_CONTAINERD is required for sandbox_config to work, and is the default from k8s 1.23 on
+    image_type = var.image_type_green_mt
 
     # Only include sandbox config if we are using gvisor
     dynamic "sandbox_config" {
@@ -172,8 +172,8 @@ resource "google_container_node_pool" "node_pool_mt" {
       }
     }
 
-    # COS_CONTAINERD is required for sandbox_config to work
-    image_type = var.enable_gvisor_blue ? "COS_CONTAINERD" : "COS"
+    # COS_CONTAINERD is required for sandbox_config to work, and is the default from k8s 1.23 on
+    image_type = var.image_type_blue_mt
 
     # Only include sandbox config if we are using gvisor
     dynamic "sandbox_config" {
@@ -259,8 +259,8 @@ resource "google_container_node_pool" "node_pool_dynamic_pods" {
       }
     }
 
-    # COS_CONTAINERD is required for sandbox_config to work
-    image_type = var.enable_gvisor_dynamic ? "COS_CONTAINERD" : "COS"
+    # COS_CONTAINERD is required for sandbox_config to work, and is the default from k8s 1.23 on
+    image_type = var.image_type_dynamic
 
     # Only include sandbox config if we are using gvisor
     dynamic "sandbox_config" {
@@ -347,8 +347,8 @@ resource "google_container_node_pool" "dynamic_blue_node_pool" {
       }
     }
 
-    # COS_CONTAINERD is required for sandbox_config to work
-    image_type = var.enable_gvisor_dynamic_blue ? "COS_CONTAINERD" : "COS"
+    # COS_CONTAINERD is required for sandbox_config to work, and is the default from k8s 1.23 on
+    image_type = var.image_type_dynamic_blue
 
     # Only include sandbox config if we are using gvisor
     dynamic "sandbox_config" {
@@ -434,8 +434,8 @@ resource "google_container_node_pool" "dynamic_green_node_pool" {
       }
     }
 
-    # COS_CONTAINERD is required for sandbox_config to work
-    image_type = var.enable_gvisor_dynamic_green ? "COS_CONTAINERD" : "COS"
+    # COS_CONTAINERD is required for sandbox_config to work, and is the default from k8s 1.23 on
+    image_type = var.image_type_dynamic_green
 
     # Only include sandbox config if we are using gvisor
     dynamic "sandbox_config" {
@@ -479,8 +479,7 @@ resource "google_container_node_pool" "node_pool_platform" {
 
   node_config {
 
-    # Container-Optimized OS
-    image_type = "COS"
+    image_type = var.image_type_blue_platform
 
     machine_type = var.machine_type_platform_blue
     disk_size_gb = var.disk_size_platform_blue
@@ -554,8 +553,7 @@ resource "google_container_node_pool" "node_pool_platform_green" {
 
   node_config {
 
-    # Container-Optimized OS
-    image_type = "COS"
+    image_type = var.image_type_green_platform
 
     machine_type = var.machine_type_platform_green
     disk_size_gb = var.disk_size_platform_green

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,7 +9,7 @@ variable "dns_managed_zone" {
 }
 
 variable "kube_version_gke" {
-  default     = "1.23.15-gke.1900"
+  default     = "1.22.17-gke.1400" # 1.23 will drop the ability to create COS node-pools
   description = "The kubernetes version to use in GKE"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,7 +9,7 @@ variable "dns_managed_zone" {
 }
 
 variable "kube_version_gke" {
-  default     = "1.21.14-gke.3000"
+  default     = "1.23.15-gke.1900"
   description = "The kubernetes version to use in GKE"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -150,6 +150,12 @@ variable "db_max_connections" {
 
 ## Platform node pool: Blue
 
+variable "image_type_blue_platform" {
+  type        = string
+  default     = "COS"
+  description = "Base OS image. COS or COS_CONTAINERD"
+}
+
 variable "enable_blue_platform_node_pool" {
   type        = bool
   default     = true
@@ -187,6 +193,12 @@ variable "platform_node_pool_taints_blue" {
 }
 
 ## Platform node pool: Green
+
+variable "image_type_green_platform" {
+  type        = string
+  default     = "COS"
+  description = "Base OS image. COS or COS_CONTAINERD"
+}
 
 variable "enable_green_platform_node_pool" {
   type        = bool
@@ -226,6 +238,12 @@ variable "platform_node_pool_taints_green" {
 
 
 ## Multi-tenant node pool: Blue
+
+variable "image_type_blue_mt" {
+  type        = string
+  default     = "COS"
+  description = "Base OS image. COS or COS_CONTAINERD"
+}
 
 variable "enable_blue_mt_node_pool" {
   type        = bool
@@ -269,6 +287,12 @@ variable "enable_gvisor_blue" {
 
 ## Multi-tenant node pool: Green
 
+variable "image_type_green_mt" {
+  type        = string
+  default     = "COS"
+  description = "Base OS image. COS or COS_CONTAINERD"
+}
+
 variable "enable_green_mt_node_pool" {
   type        = bool
   default     = false
@@ -311,6 +335,12 @@ variable "enable_gvisor_green" {
 
 ## Dynamic node pool (legacy pre-blue-green pool)
 
+variable "image_type_dynamic" {
+  type        = string
+  default     = "COS"
+  description = "Base OS image. COS or COS_CONTAINERD"
+}
+
 variable "create_dynamic_pods_nodepool" {
   type        = bool
   default     = false
@@ -352,6 +382,12 @@ variable "machine_type_dynamic" {
 }
 
 ## Dynamic node pool blue (added 2020-12-16)
+
+variable "image_type_dynamic_blue" {
+  type        = string
+  default     = "COS"
+  description = "Base OS image. COS or COS_CONTAINERD"
+}
 
 variable "enable_dynamic_blue_node_pool" {
   type        = bool
@@ -400,6 +436,12 @@ variable "enable_gvisor_dynamic_blue" {
 }
 
 ## Dynamic node pool green (added 2020-12-16)
+
+variable "image_type_dynamic_green" {
+  type        = string
+  default     = "COS"
+  description = "Base OS image. COS or COS_CONTAINERD"
+}
 
 variable "enable_dynamic_green_node_pool" {
   type        = bool


### PR DESCRIPTION
Issue https://github.com/astronomer/issues/issues/5242

Allow us to specify the image_type for each node_pool so we can make a gentle switch from COS to COS_CONTAINERD which is required for k8s 1.24.